### PR TITLE
ADM remediating 190 vulnerable artifacts

### DIFF
--- a/chunjun-clients/pom.xml
+++ b/chunjun-clients/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-hdfs</artifactId>
-			<version>${hadoop2.version}</version>
+			<version>3.3.5</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>commons-cli</artifactId>
@@ -98,7 +98,7 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
-			<version>${hadoop2.version}</version>
+			<version>3.3.5</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>commons-cli</artifactId>
@@ -130,7 +130,7 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-yarn-common</artifactId>
-			<version>${hadoop2.version}</version>
+			<version>2.10.2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>commons-cli</artifactId>
@@ -158,7 +158,7 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-yarn-client</artifactId>
-			<version>${hadoop2.version}</version>
+			<version>2.10.2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>commons-cli</artifactId>
@@ -173,7 +173,7 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-mapreduce-client-core</artifactId>
-			<version>${hadoop2.version}</version>
+			<version>2.10.2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-api</artifactId>
@@ -188,7 +188,7 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-yarn-api</artifactId>
-			<version>${hadoop2.version}</version>
+			<version>3.3.1</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>commons-logging</artifactId>
@@ -199,7 +199,7 @@
 		<dependency>
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro</artifactId>
-			<version>1.8.2</version>
+			<version>1.11.0</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-api</artifactId>

--- a/chunjun-connectors/chunjun-connector-cassandra/pom.xml
+++ b/chunjun-connectors/chunjun-connector-cassandra/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.datastax.cassandra</groupId>
 			<artifactId>cassandra-driver-core</artifactId>
-			<version>${cassandra.driver.version}</version>
+			<version>4.0.0</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-api</artifactId>

--- a/chunjun-connectors/chunjun-connector-elasticsearch-base/pom.xml
+++ b/chunjun-connectors/chunjun-connector-elasticsearch-base/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-elasticsearch-base</artifactId>
-			<version>${flink.version}</version>
+			<version>1.16.2</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/chunjun-connectors/chunjun-connector-elasticsearch6/pom.xml
+++ b/chunjun-connectors/chunjun-connector-elasticsearch6/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.elasticsearch.client</groupId>
 			<artifactId>elasticsearch-rest-high-level-client</artifactId>
-			<version>6.3.1</version>
+			<version>8.0.0-alpha1</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.logging.log4j</groupId>
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-elasticsearch6</artifactId>
-			<version>${flink.version}</version>
+			<version>1.16.2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>log4j-to-slf4j</artifactId>

--- a/chunjun-connectors/chunjun-connector-elasticsearch7/pom.xml
+++ b/chunjun-connectors/chunjun-connector-elasticsearch7/pom.xml
@@ -39,13 +39,13 @@
 		<dependency>
 			<groupId>org.elasticsearch.client</groupId>
 			<artifactId>elasticsearch-rest-high-level-client</artifactId>
-			<version>7.5.1</version>
+			<version>8.0.0-alpha1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-elasticsearch7</artifactId>
-			<version>${flink.version}</version>
+			<version>1.16.2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>log4j-to-slf4j</artifactId>

--- a/chunjun-connectors/chunjun-connector-ftp/pom.xml
+++ b/chunjun-connectors/chunjun-connector-ftp/pom.xml
@@ -57,7 +57,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>4.1.2</version>
+			<version>5.1.0</version>
 		</dependency>
 
 		<dependency>

--- a/chunjun-connectors/chunjun-connector-hbase-base/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hbase-base/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-client</artifactId>
-			<version>${hbase.version}</version>
+			<version>2.1.6</version>
 			<exclusions>
 				<!-- Remove unneeded dependency, which is conflicting with our jetty-util version. -->
 				<exclusion>

--- a/chunjun-connectors/chunjun-connector-hbase2/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hbase2/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
 			<artifactId>hbase-client</artifactId>
-			<version>${hbase.version}</version>
+			<version>2.2.1</version>
 			<exclusions>
 				<!-- Remove unneeded dependency, which is conflicting with our jetty-util version. -->
 				<exclusion>

--- a/chunjun-connectors/chunjun-connector-hdfs/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hdfs/pom.xml
@@ -45,13 +45,13 @@
 		<dependency>
 			<artifactId>groovy-all</artifactId>
 			<groupId>org.codehaus.groovy</groupId>
-			<version>2.4.4</version>
+			<version>2.5.18</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-exec</artifactId>
-			<version>${hive.version}</version>
+			<version>4.0.0-alpha-2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>calcite-core</artifactId>
@@ -119,7 +119,7 @@
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-serde</artifactId>
-			<version>${hive.version}</version>
+			<version>4.0.0-alpha-2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.hadoop</groupId>

--- a/chunjun-connectors/chunjun-connector-hive/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hive/pom.xml
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-exec</artifactId>
-			<version>2.1.0</version>
+			<version>4.0.0-alpha-2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>log4j-api</artifactId>
@@ -121,7 +121,7 @@
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-serde</artifactId>
-			<version>2.1.0</version>
+			<version>4.0.0-alpha-2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>commons-cli</artifactId>
@@ -157,7 +157,7 @@
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-jdbc</artifactId>
-			<version>2.1.0</version>
+			<version>4.0.0-alpha-2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-log4j12</artifactId>

--- a/chunjun-connectors/chunjun-connector-hive3/pom.xml
+++ b/chunjun-connectors/chunjun-connector-hive3/pom.xml
@@ -124,7 +124,7 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-yarn-common</artifactId>
-			<version>${hadoop3.version}</version>
+			<version>3.3.5</version>
 			<scope>provided</scope>
 			<exclusions>
 				<exclusion>

--- a/chunjun-connectors/chunjun-connector-iceberg/pom.xml
+++ b/chunjun-connectors/chunjun-connector-iceberg/pom.xml
@@ -63,19 +63,19 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-hdfs</artifactId>
-			<version>${hadoop.version}</version>
+			<version>3.3.3</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
-			<version>${hadoop.version}</version>
+			<version>3.3.5</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-client</artifactId>
-			<version>${hadoop.version}</version>
+			<version>3.3.5</version>
 		</dependency>
 
 	</dependencies>

--- a/chunjun-connectors/chunjun-connector-influxdb/pom.xml
+++ b/chunjun-connectors/chunjun-connector-influxdb/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>org.influxdb</groupId>
 			<artifactId>influxdb-java</artifactId>
-			<version>2.21</version>
+			<version>2.23</version>
 		</dependency>
 	</dependencies>
 

--- a/chunjun-connectors/chunjun-connector-jdbc-base/pom.xml
+++ b/chunjun-connectors/chunjun-connector-jdbc-base/pom.xml
@@ -49,13 +49,13 @@
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-jdbc-client</artifactId>
-			<version>${vertx.version}</version>
+			<version>3.9.15</version>
 		</dependency>
 
 		<dependency>
 			<groupId>io.vertx</groupId>
 			<artifactId>vertx-core</artifactId>
-			<version>${vertx.version}</version>
+			<version>3.9.15</version>
 		</dependency>
 
 		<dependency>

--- a/chunjun-connectors/chunjun-connector-kafka/pom.xml
+++ b/chunjun-connectors/chunjun-connector-kafka/pom.xml
@@ -50,13 +50,13 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-avro-confluent-registry</artifactId>
-			<version>${flink.version}</version>
+			<version>1.16.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro</artifactId>
-			<version>1.10.0</version>
+			<version>1.11.0</version>
 		</dependency>
 
 		<!--flink formats-->

--- a/chunjun-connectors/chunjun-connector-mysql/pom.xml
+++ b/chunjun-connectors/chunjun-connector-mysql/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.49</version>
+            <version>8.0.31</version>
         </dependency>
     </dependencies>
 

--- a/chunjun-connectors/chunjun-connector-mysqlcdc/pom.xml
+++ b/chunjun-connectors/chunjun-connector-mysqlcdc/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.46</version>
+			<version>8.0.31</version>
 		</dependency>
 		<dependency>
 			<groupId>com.alibaba.ververica</groupId>

--- a/chunjun-connectors/chunjun-connector-oceanbase/pom.xml
+++ b/chunjun-connectors/chunjun-connector-oceanbase/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>com.oceanbase</groupId>
 			<artifactId>oceanbase-client</artifactId>
-			<version>${oceanbase.client.version}</version>
+			<version>2.4.1</version>
 		</dependency>
 
 		<dependency>

--- a/chunjun-connectors/chunjun-connector-oceanbasecdc/pom.xml
+++ b/chunjun-connectors/chunjun-connector-oceanbasecdc/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
-			<version>3.18.2</version>
+			<version>3.19.6</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>
@@ -49,7 +49,7 @@
 		<dependency>
 			<groupId>com.oceanbase.logclient</groupId>
 			<artifactId>logproxy-client</artifactId>
-			<version>1.0.7</version>
+			<version>1.1.0</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/chunjun-connectors/chunjun-connector-postgresql/pom.xml
+++ b/chunjun-connectors/chunjun-connector-postgresql/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.2.19</version>
+			<version>42.2.27</version>
 		</dependency>
 	</dependencies>
 

--- a/chunjun-connectors/chunjun-connector-socket/pom.xml
+++ b/chunjun-connectors/chunjun-connector-socket/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty-all</artifactId>
-			<version>4.1.85.Final</version>
+			<version>4.1.86.Final</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/chunjun-connectors/chunjun-connector-solr/pom.xml
+++ b/chunjun-connectors/chunjun-connector-solr/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>org.apache.solr</groupId>
 			<artifactId>solr-solrj</artifactId>
-			<version>8.8.2</version>
+			<version>9.1.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>

--- a/chunjun-connectors/chunjun-connector-starrocks/pom.xml
+++ b/chunjun-connectors/chunjun-connector-starrocks/pom.xml
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.49</version>
+			<version>8.0.31</version>
 		</dependency>
 
 		<dependency>
@@ -51,13 +51,13 @@
 		<dependency>
 			<groupId>org.apache.arrow</groupId>
 			<artifactId>arrow-vector</artifactId>
-			<version>${arrow.version}</version>
+			<version>6.0.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.arrow</groupId>
 			<artifactId>arrow-memory-netty</artifactId>
-			<version>${arrow.version}</version>
+			<version>6.0.0</version>
 		</dependency>
 	</dependencies>
 

--- a/chunjun-core/pom.xml
+++ b/chunjun-core/pom.xml
@@ -110,20 +110,20 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>${chunjun.guava.version}</version>
+			<version>30.0-jre</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.7</version>
+			<version>2.8.9</version>
 		</dependency>
 
 		<!-- Flink dependencies -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-core</artifactId>
-			<version>${flink.version}</version>
+			<version>1.16.2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-api</artifactId>
@@ -135,7 +135,7 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java</artifactId>
-			<version>${flink.version}</version>
+			<version>1.16.2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-api</artifactId>
@@ -147,7 +147,7 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime</artifactId>
-			<version>${flink.version}</version>
+			<version>1.16.2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-api</artifactId>
@@ -160,7 +160,7 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-api-java-bridge</artifactId>
-			<version>${flink.version}</version>
+			<version>1.16.2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>slf4j-api</artifactId>
@@ -178,13 +178,13 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-common</artifactId>
-			<version>${flink.version}</version>
+			<version>1.16.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-runtime</artifactId>
-			<version>${flink.version}</version>
+			<version>1.16.2</version>
 		</dependency>
 		<!-- flink sql -->
 
@@ -205,7 +205,7 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-yarn</artifactId>
-			<version>${flink.version}</version>
+			<version>1.16.2</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>flink-shaded-hadoop2</artifactId>
@@ -247,7 +247,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>${http.version}</version>
+			<version>4.5.13</version>
 		</dependency>
 
 		<dependency>
@@ -258,7 +258,7 @@
 		<dependency>
 			<groupId>commons-net</groupId>
 			<artifactId>commons-net</artifactId>
-			<version>3.1</version>
+			<version>3.9.0</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
@@ -278,14 +278,14 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime</artifactId>
-			<version>${flink.version}</version>
+			<version>1.16.2</version>
 			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java</artifactId>
-			<version>${flink.version}</version>
+			<version>1.16.2</version>
 			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>

--- a/chunjun-dirty/chunjun-dirty-mysql/pom.xml
+++ b/chunjun-dirty/chunjun-dirty-mysql/pom.xml
@@ -42,7 +42,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>${mysql.connector.version}</version>
+			<version>8.0.31</version>
 		</dependency>
 	</dependencies>
 

--- a/chunjun-local-test/pom.xml
+++ b/chunjun-local-test/pom.xml
@@ -110,13 +110,13 @@
 		<dependency>
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro</artifactId>
-			<version>1.10.1</version>
+			<version>1.11.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.parquet</groupId>
 			<artifactId>parquet-avro</artifactId>
-			<version>1.12.2</version>
+			<version>1.13.0</version>
 		</dependency>
 
 		<!--Test Connector End. Do not Add directly -->

--- a/chunjun-metrics/chunjun-metrics-mysql/pom.xml
+++ b/chunjun-metrics/chunjun-metrics-mysql/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.46</version>
+			<version>8.0.31</version>
 		</dependency>
 	</dependencies>
 

--- a/chunjun-restore/chunjun-restore-mysql/pom.xml
+++ b/chunjun-restore/chunjun-restore-mysql/pom.xml
@@ -51,7 +51,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>${mysql.version}</version>
+			<version>8.0.31</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
-			<version>${hadoop2.version}</version>
+			<version>3.3.5</version>
 			<scope>provided</scope>
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
Vulnerabilities: [Remediation Run Detect Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.iad.amaaaaaa5f5ialyabhcmt3keesaokzwirw5aqpjgzuu57cnbwqn3wgktasra/runs/ocid1.admremediationrun.oc1.iad.amaaaaaa5f5ialyaew4g2klqoexba2guj43zq6kzeyy64ojkdr5m7zja33hq/stages/DETECT)
* com.dtstack.chunjun:chunjun-clients:master
  * com.dtstack.chunjun:chunjun-core:master
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
    * com.google.code.gson:gson:2.7
      * CVE-2022-25647
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * com.jamesmurty.utils:java-xmlbuilder:0.4
      * CVE-2014-125087
    * com.nimbusds:nimbus-jose-jwt:4.41.1
      * CVE-2019-17195
    * com.squareup.okhttp:okhttp:2.4.0
      * CVE-2016-2402
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.7.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-net:commons-net:3.1
      * CVE-2021-37533
    * io.netty:netty:3.6.2.Final
      * CVE-2014-3488
      * CVE-2015-2156
    * net.minidev:json-smart:2.3
      * CVE-2021-27568
      * CVE-2023-1370
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.hadoop:hadoop-common:2.8.5
      * CVE-2020-9492
      * CVE-2022-26612
    * org.apache.httpcomponents:httpclient:4.5.3
      * CVE-2020-13956
    * org.apache.zookeeper:zookeeper:3.4.6
      * CVE-2016-5017
      * CVE-2017-5637
      * CVE-2018-8012
      * CVE-2019-0201
    * org.codehaus.jackson:jackson-mapper-asl:1.9.13
      * CVE-2019-10172
    * org.codehaus.jettison:jettison:1.1
      * CVE-2022-40149
      * CVE-2022-40150
      * CVE-2022-45685
      * CVE-2022-45693
      * CVE-2023-1436
    * xerces:xercesImpl:2.9.1
      * CVE-2009-2625
      * CVE-2012-0881
      * CVE-2013-4002
      * CVE-2020-14338
      * CVE-2022-23437
  * org.apache.avro:avro:1.8.2
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
    * org.codehaus.jackson:jackson-mapper-asl:1.9.13
      * CVE-2019-10172
  * org.apache.flink:flink-clients:1.16.1
    * com.google.code.gson:gson:2.7
      * CVE-2022-25647
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * com.jamesmurty.utils:java-xmlbuilder:0.4
      * CVE-2014-125087
    * com.nimbusds:nimbus-jose-jwt:4.41.1
      * CVE-2019-17195
    * com.squareup.okhttp:okhttp:2.4.0
      * CVE-2016-2402
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.7.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-net:commons-net:3.1
      * CVE-2021-37533
    * io.netty:netty:3.6.2.Final
      * CVE-2014-3488
      * CVE-2015-2156
    * net.minidev:json-smart:2.3
      * CVE-2021-27568
      * CVE-2023-1370
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.hadoop:hadoop-common:2.8.5
      * CVE-2020-9492
      * CVE-2022-26612
    * org.apache.httpcomponents:httpclient:4.5.3
      * CVE-2020-13956
    * org.apache.zookeeper:zookeeper:3.4.6
      * CVE-2016-5017
      * CVE-2017-5637
      * CVE-2018-8012
      * CVE-2019-0201
    * org.codehaus.jackson:jackson-mapper-asl:1.9.13
      * CVE-2019-10172
    * org.codehaus.jettison:jettison:1.1
      * CVE-2022-40149
      * CVE-2022-40150
      * CVE-2022-45685
      * CVE-2022-45693
      * CVE-2023-1436
    * xerces:xercesImpl:2.9.1
      * CVE-2009-2625
      * CVE-2012-0881
      * CVE-2013-4002
      * CVE-2020-14338
      * CVE-2022-23437
  * org.apache.flink:flink-table-planner-loader:1.16.1
    * com.google.code.gson:gson:2.7
      * CVE-2022-25647
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * com.jamesmurty.utils:java-xmlbuilder:0.4
      * CVE-2014-125087
    * com.nimbusds:nimbus-jose-jwt:4.41.1
      * CVE-2019-17195
    * com.squareup.okhttp:okhttp:2.4.0
      * CVE-2016-2402
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.7.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-net:commons-net:3.1
      * CVE-2021-37533
    * io.netty:netty:3.6.2.Final
      * CVE-2014-3488
      * CVE-2015-2156
    * net.minidev:json-smart:2.3
      * CVE-2021-27568
      * CVE-2023-1370
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.hadoop:hadoop-common:2.8.5
      * CVE-2020-9492
      * CVE-2022-26612
    * org.apache.httpcomponents:httpclient:4.5.3
      * CVE-2020-13956
    * org.apache.zookeeper:zookeeper:3.4.6
      * CVE-2016-5017
      * CVE-2017-5637
      * CVE-2018-8012
      * CVE-2019-0201
    * org.codehaus.jackson:jackson-mapper-asl:1.9.13
      * CVE-2019-10172
    * org.codehaus.jettison:jettison:1.1
      * CVE-2022-40149
      * CVE-2022-40150
      * CVE-2022-45685
      * CVE-2022-45693
      * CVE-2023-1436
    * xerces:xercesImpl:2.9.1
      * CVE-2009-2625
      * CVE-2012-0881
      * CVE-2013-4002
      * CVE-2020-14338
      * CVE-2022-23437
  * org.apache.hadoop:hadoop-common:2.8.5
    * CVE-2020-9492
    * CVE-2022-26612
    * com.google.code.gson:gson:2.7
      * CVE-2022-25647
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * com.jamesmurty.utils:java-xmlbuilder:0.4
      * CVE-2014-125087
    * com.nimbusds:nimbus-jose-jwt:4.41.1
      * CVE-2019-17195
    * commons-beanutils:commons-beanutils-core:1.8.0
      * CVE-2014-0114
    * commons-beanutils:commons-beanutils:1.7.0
      * CVE-2014-0114
      * CVE-2019-10086
    * commons-net:commons-net:3.1
      * CVE-2021-37533
    * io.netty:netty:3.6.2.Final
      * CVE-2014-3488
      * CVE-2015-2156
    * net.minidev:json-smart:2.3
      * CVE-2021-27568
      * CVE-2023-1370
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.httpcomponents:httpclient:4.5.3
      * CVE-2020-13956
    * org.apache.zookeeper:zookeeper:3.4.6
      * CVE-2016-5017
      * CVE-2017-5637
      * CVE-2018-8012
      * CVE-2019-0201
    * org.codehaus.jackson:jackson-mapper-asl:1.9.13
      * CVE-2019-10172
    * org.codehaus.jettison:jettison:1.1
      * CVE-2022-40149
      * CVE-2022-40150
      * CVE-2022-45685
      * CVE-2022-45693
      * CVE-2023-1436
  * org.apache.hadoop:hadoop-hdfs:2.8.5
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * com.squareup.okhttp:okhttp:2.4.0
      * CVE-2016-2402
    * io.netty:netty:3.6.2.Final
      * CVE-2014-3488
      * CVE-2015-2156
    * org.codehaus.jackson:jackson-mapper-asl:1.9.13
      * CVE-2019-10172
    * xerces:xercesImpl:2.9.1
      * CVE-2009-2625
      * CVE-2012-0881
      * CVE-2013-4002
      * CVE-2020-14338
      * CVE-2022-23437
  * org.apache.hadoop:hadoop-mapreduce-client-core:2.8.5
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * io.netty:netty:3.6.2.Final
      * CVE-2014-3488
      * CVE-2015-2156
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
    * org.codehaus.jackson:jackson-mapper-asl:1.9.13
      * CVE-2019-10172
    * org.codehaus.jettison:jettison:1.1
      * CVE-2022-40149
      * CVE-2022-40150
      * CVE-2022-45685
      * CVE-2022-45693
      * CVE-2023-1436
  * org.apache.hadoop:hadoop-yarn-api:2.8.5
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
  * org.apache.hadoop:hadoop-yarn-client:2.8.5
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
    * org.codehaus.jackson:jackson-mapper-asl:1.9.13
      * CVE-2019-10172
    * org.codehaus.jettison:jettison:1.1
      * CVE-2022-40149
      * CVE-2022-40150
      * CVE-2022-45685
      * CVE-2022-45693
      * CVE-2023-1436
  * org.apache.hadoop:hadoop-yarn-common:2.8.5
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
    * org.codehaus.jackson:jackson-mapper-asl:1.9.13
      * CVE-2019-10172
    * org.codehaus.jettison:jettison:1.1
      * CVE-2022-40149
      * CVE-2022-40150
      * CVE-2022-45685
      * CVE-2022-45693
      * CVE-2023-1436
  * org.apache.logging.log4j:log4j-1.2-api:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
  * org.apache.logging.log4j:log4j-core:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
  * org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
* com.dtstack.chunjun:chunjun-connector-binlog:master
  * com.alibaba.otter:canal.common:1.1.6
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
  * com.alibaba.otter:canal.filter:1.1.6
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.googlecode.aviator:aviator:2.2.1
      * CVE-2021-41862
      * CVE-2023-24163
  * com.alibaba.otter:canal.parse:1.1.6
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.googlecode.aviator:aviator:2.2.1
      * CVE-2021-41862
      * CVE-2023-24163
    * com.h2database:h2:1.4.196
      * CVE-2021-42392
      * CVE-2022-23221
      * CVE-2022-45868
    * mysql:mysql-connector-java:5.1.48
      * CVE-2018-3258
      * CVE-2019-2692
      * CVE-2020-2875
      * CVE-2020-2933
      * CVE-2020-2934
      * CVE-2022-21363
  * com.google.guava:guava:19.0
    * CVE-2018-10237
    * CVE-2020-8908
* com.dtstack.chunjun:chunjun-connector-cassandra:master
  * com.datastax.cassandra:cassandra-driver-core:3.11.0
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
  * org.apache.logging.log4j:log4j-1.2-api:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
  * org.apache.logging.log4j:log4j-core:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
  * org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
* com.dtstack.chunjun:chunjun-connector-clickhouse:master
  * com.dtstack.chunjun:chunjun-connector-jdbc-base:master
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
    * io.netty:netty-codec-http2:4.1.60.Final
      * CVE-2021-21409
    * io.netty:netty-codec-http:4.1.60.Final
      * CVE-2021-43797
      * CVE-2022-24823
    * io.netty:netty-codec:4.1.60.Final
      * CVE-2021-37136
      * CVE-2021-37137
  * org.apache.logging.log4j:log4j-1.2-api:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
  * org.apache.logging.log4j:log4j-core:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
  * org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
  * ru.yandex.clickhouse:clickhouse-jdbc:0.3.2
    * com.google.code.gson:gson:2.8.8
      * CVE-2022-25647
* com.dtstack.chunjun:chunjun-connector-db2:master
  * com.dtstack.chunjun:chunjun-connector-jdbc-base:master
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
    * io.netty:netty-codec-http2:4.1.60.Final
      * CVE-2021-21409
    * io.netty:netty-codec-http:4.1.60.Final
      * CVE-2021-43797
      * CVE-2022-24823
    * io.netty:netty-codec:4.1.60.Final
      * CVE-2021-37136
      * CVE-2021-37137
  * org.apache.logging.log4j:log4j-1.2-api:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
  * org.apache.logging.log4j:log4j-core:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
  * org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
* com.dtstack.chunjun:chunjun-connector-dm:master
  * com.dtstack.chunjun:chunjun-connector-jdbc-base:master
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
    * io.netty:netty-codec-http2:4.1.60.Final
      * CVE-2021-21409
    * io.netty:netty-codec-http:4.1.60.Final
      * CVE-2021-43797
      * CVE-2022-24823
    * io.netty:netty-codec:4.1.60.Final
      * CVE-2021-37136
      * CVE-2021-37137
  * org.apache.logging.log4j:log4j-1.2-api:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
  * org.apache.logging.log4j:log4j-core:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
  * org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
* com.dtstack.chunjun:chunjun-connector-doris:master
  * com.dtstack.chunjun:chunjun-connector-mysql:master
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
    * io.netty:netty-codec-http2:4.1.60.Final
      * CVE-2021-21409
    * io.netty:netty-codec-http:4.1.60.Final
      * CVE-2021-43797
      * CVE-2022-24823
    * io.netty:netty-codec:4.1.60.Final
      * CVE-2021-37136
      * CVE-2021-37137
    * mysql:mysql-connector-java:5.1.49
      * CVE-2018-3258
      * CVE-2019-2692
      * CVE-2022-21363
  * org.apache.logging.log4j:log4j-1.2-api:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
  * org.apache.logging.log4j:log4j-core:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
  * org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
* com.dtstack.chunjun:chunjun-connector-elasticsearch-base:master
  * org.apache.flink:flink-connector-elasticsearch-base:1.16.1
    * com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.4
      * CVE-2020-28491
    * org.apache.httpcomponents:httpclient:4.5.10
      * CVE-2020-13956
    * org.elasticsearch:elasticsearch:7.10.2
      * CVE-2021-22134
      * CVE-2021-22144
      * CVE-2021-22145
    * org.yaml:snakeyaml:1.26
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.apache.logging.log4j:log4j-1.2-api:2.17.1
    * org.yaml:snakeyaml:1.26
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.apache.logging.log4j:log4j-core:2.17.1
    * org.yaml:snakeyaml:1.26
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
    * org.yaml:snakeyaml:1.26
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
* com.dtstack.chunjun:chunjun-connector-elasticsearch6:master
  * com.dtstack.chunjun:chunjun-connector-elasticsearch-base:master
    * com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.10
      * CVE-2020-28491
    * org.apache.httpcomponents:httpclient:4.5.2
      * CVE-2020-13956
    * org.elasticsearch:elasticsearch:6.3.1
      * CVE-2018-3831
      * CVE-2019-7611
      * CVE-2019-7614
      * CVE-2020-7019
      * CVE-2020-7020
      * CVE-2020-7021
      * CVE-2021-22135
      * CVE-2021-22137
      * CVE-2021-22144
    * org.yaml:snakeyaml:1.17
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.apache.flink:flink-connector-elasticsearch6:1.16.1
    * com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.10
      * CVE-2020-28491
    * org.apache.httpcomponents:httpclient:4.5.2
      * CVE-2020-13956
    * org.elasticsearch:elasticsearch:6.3.1
      * CVE-2018-3831
      * CVE-2019-7611
      * CVE-2019-7614
      * CVE-2020-7019
      * CVE-2020-7020
      * CVE-2020-7021
      * CVE-2021-22135
      * CVE-2021-22137
      * CVE-2021-22144
    * org.yaml:snakeyaml:1.17
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.apache.logging.log4j:log4j-1.2-api:2.17.1
    * org.yaml:snakeyaml:1.17
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.apache.logging.log4j:log4j-core:2.17.1
    * org.yaml:snakeyaml:1.17
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
    * org.yaml:snakeyaml:1.17
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.elasticsearch.client:elasticsearch-rest-high-level-client:6.3.1
    * com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.10
      * CVE-2020-28491
    * org.apache.httpcomponents:httpclient:4.5.2
      * CVE-2020-13956
    * org.elasticsearch:elasticsearch:6.3.1
      * CVE-2018-3831
      * CVE-2019-7611
      * CVE-2019-7614
      * CVE-2020-7019
      * CVE-2020-7020
      * CVE-2020-7021
      * CVE-2021-22135
      * CVE-2021-22137
      * CVE-2021-22144
    * org.yaml:snakeyaml:1.17
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
* com.dtstack.chunjun:chunjun-connector-elasticsearch7:master
  * com.dtstack.chunjun:chunjun-connector-elasticsearch-base:master
    * com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.11
      * CVE-2020-28491
    * org.apache.httpcomponents:httpclient:4.5.10
      * CVE-2020-13956
    * org.elasticsearch:elasticsearch:7.5.1
      * CVE-2020-7009
      * CVE-2020-7014
      * CVE-2020-7019
      * CVE-2020-7020
      * CVE-2020-7021
      * CVE-2021-22144
    * org.yaml:snakeyaml:1.17
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.apache.flink:flink-connector-elasticsearch7:1.16.1
    * com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.11
      * CVE-2020-28491
    * org.apache.httpcomponents:httpclient:4.5.10
      * CVE-2020-13956
    * org.elasticsearch:elasticsearch:7.5.1
      * CVE-2020-7009
      * CVE-2020-7014
      * CVE-2020-7019
      * CVE-2020-7020
      * CVE-2020-7021
      * CVE-2021-22144
    * org.yaml:snakeyaml:1.17
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.apache.logging.log4j:log4j-1.2-api:2.17.1
    * org.yaml:snakeyaml:1.17
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.apache.logging.log4j:log4j-core:2.17.1
    * org.yaml:snakeyaml:1.17
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
    * org.yaml:snakeyaml:1.17
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
  * org.elasticsearch.client:elasticsearch-rest-high-level-client:7.5.1
    * com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.11
      * CVE-2020-28491
    * org.apache.httpcomponents:httpclient:4.5.10
      * CVE-2020-13956
    * org.elasticsearch:elasticsearch:7.5.1
      * CVE-2020-7009
      * CVE-2020-7014
      * CVE-2020-7019
      * CVE-2020-7020
      * CVE-2020-7021
      * CVE-2021-22144
    * org.yaml:snakeyaml:1.17
      * CVE-2017-18640
      * CVE-2022-1471
      * CVE-2022-25857
      * CVE-2022-38749
      * CVE-2022-38750
      * CVE-2022-38751
      * CVE-2022-38752
      * CVE-2022-41854
* com.dtstack.chunjun:chunjun-connector-ftp:master
  * com.alibaba:easyexcel:3.0.1
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
  * org.apache.logging.log4j:log4j-1.2-api:2.17.1
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
  * org.apache.logging.log4j:log4j-core:2.17.1
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
  * org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
  * org.apache.poi:poi-ooxml:4.1.2
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
* com.dtstack.chunjun:chunjun-connector-greenplum:master
  * com.dtstack.chunjun:chunjun-connector-postgresql:master
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
    * io.netty:netty-codec-http2:4.1.60.Final
      * CVE-2021-21409
    * io.netty:netty-codec-http:4.1.60.Final
      * CVE-2021-43797
      * CVE-2022-24823
    * io.netty:netty-codec:4.1.60.Final
      * CVE-2021-37136
      * CVE-2021-37137
    * org.postgresql:postgresql:42.2.19
      * CVE-2022-21724
      * CVE-2022-31197
      * CVE-2022-41946
  * org.apache.logging.log4j:log4j-1.2-api:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
  * org.apache.logging.log4j:log4j-core:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
  * org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
* com.dtstack.chunjun:chunjun-connector-hbase-1.4:master
  * com.dtstack.chunjun:chunjun-connector-hbase-base:master
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * io.netty:netty-all:4.1.8.Final
      * CVE-2019-16869
      * CVE-2019-20445
      * CVE-2020-11612
    * junit:junit:4.12
      * CVE-2020-15250
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.zookeeper:zookeeper:3.4.5
      * CVE-2016-5017
      * CVE-2017-5637
      * CVE-2018-8012
      * CVE-2019-0201
    * org.codehaus.jackson:jackson-mapper-asl:1.9.13
      * CVE-2019-10172
  * org.apache.logging.log4j:log4j-1.2-api:2.17.1
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
  * org.apache.logging.log4j:log4j-core:2.17.1
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
  * org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
  * org.hbase:asynchbase:1.8.2
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * io.netty:netty:3.9.4.Final
      * CVE-2015-2156
    * org.apache.zookeeper:zookeeper:3.4.5
      * CVE-2016-5017
      * CVE-2017-5637
      * CVE-2018-8012
      * CVE-2019-0201
* com.dtstack.chunjun:chunjun-connector-hbase-base:master
  * org.apache.hbase:hbase-client:1.4.3
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * io.netty:netty-all:4.1.8.Final
      * CVE-2019-16869
      * CVE-2019-20445
      * CVE-2020-11612
    * junit:junit:4.12
      * CVE-2020-15250
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.zookeeper:zookeeper:3.4.10
      * CVE-2019-0201
    * org.codehaus.jackson:jackson-mapper-asl:1.9.13
      * CVE-2019-10172
  * org.apache.logging.log4j:log4j-1.2-api:2.17.1
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
  * org.apache.logging.log4j:log4j-core:2.17.1
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
  * org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
* com.dtstack.chunjun:chunjun-connector-hbase2:master
  * com.dtstack.chunjun:chunjun-connector-hbase-base:master
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * junit:junit:4.12
      * CVE-2020-15250
  * org.apache.hbase:hbase-client:2.2.0
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * junit:junit:4.12
      * CVE-2020-15250
* com.dtstack.chunjun:chunjun-connector-hdfs:master
  * org.apache.hive:hive-exec:3.1.3
    * com.fasterxml.jackson.core:jackson-databind:2.12.6
      * CVE-2020-36518
      * CVE-2022-42003
      * CVE-2022-42004
    * com.fasterxml.woodstox:woodstox-core:5.0.3
      * CVE-2022-40152
    * com.google.code.gson:gson:2.2.4
      * CVE-2022-25647
    * com.google.guava:guava:19.0
      * CVE-2018-10237
      * CVE-2020-8908
    * com.google.protobuf:protobuf-java:2.5.0
      * CVE-2015-5237
      * CVE-2021-22569
      * CVE-2022-3171
      * CVE-2022-3509
      * CVE-2022-3510
    * com.nimbusds:nimbus-jose-jwt:4.41.1
      * CVE-2019-17195
    * commons-beanutils:commons-beanutils:1.9.3
      * CVE-2019-10086
    * commons-net:commons-net:3.6
      * CVE-2021-37533
    * io.netty:netty-common:4.1.17.Final
      * CVE-2021-21290
    * io.netty:netty:3.7.0.Final
      * CVE-2014-3488
      * CVE-2015-2156
    * net.minidev:json-smart:2.3
      * CVE-2021-27568
      * CVE-2023-1370
    * org.apache.ant:ant:1.9.1
      * CVE-2020-1945
      * CVE-2021-36373
      * CVE-2021-36374
    * org.apache.calcite:calcite-druid:1.16.0
      * CVE-2020-13955
    * org.apache.commons:commons-compress:1.20
      * CVE-2021-35515
      * CVE-2021-35516
      * CVE-2021-35517
      * CVE-2021-36090
    * org.apache.hadoop:hadoop-common:3.1.0
      * CVE-2018-8009
      * CVE-2020-9492
      * CVE-2021-37404
      * CVE-2022-26612
    * org.apache.hadoop:hadoop-yarn-server-common:3.1.0
      * CVE-2021-33036
    * org.apache.httpcomponents:httpclient:4.5.2
      * CVE-2020-13956
    * org.apache.ivy:ivy:2.4.0
      * CVE-2022-37865
      * CVE-2022-37866
...
Dependencies upgraded: [Remediation Run Recommend Stage](https://cloud.oracle.com/adm/remediationRecipes/ocid1.admremediationrecipe.oc1.iad.amaaaaaa5f5ialyabhcmt3keesaokzwirw5aqpjgzuu57cnbwqn3wgktasra/runs/ocid1.admremediationrun.oc1.iad.amaaaaaa5f5ialyaew4g2klqoexba2guj43zq6kzeyy64ojkdr5m7zja33hq/stages/RECOMMEND)

* com.datastax.cassandra:cassandra-driver-core:3.11.0 -> 4.0.0
* com.fasterxml.jackson.core:jackson-databind:2.12.6 -> 2.13.4.1
* com.google.code.gson:gson:2.7 -> 2.8.9
* com.google.guava:guava:19.0 -> 30.0-android
* com.google.guava:guava:19.0 -> 30.0-android
* com.google.guava:guava:19.0 -> 30.0-android
* com.google.guava:guava:19.0 -> 30.0-android
* com.google.guava:guava:19.0 -> 30.0-android
* com.google.guava:guava:27.0-jre -> 30.0-jre
* com.google.guava:guava:29.0-jre -> 30.0-jre
* com.google.protobuf:protobuf-java:3.18.2 -> 3.19.6
* com.oceanbase.logclient:logproxy-client:1.0.7 -> 1.1.0
* com.oceanbase:oceanbase-client:2.4.0 -> 2.4.1
* com.oceanbase:oceanbase-client:2.4.0 -> 2.4.1
* commons-net:commons-net:3.1 -> 3.9.0
* io.netty:netty-all:4.1.85.Final -> 4.1.86.Final
* io.vertx:vertx-core:3.9.7 -> 3.9.15
* io.vertx:vertx-core:3.9.7 -> 3.9.15
* io.vertx:vertx-core:3.9.7 -> 3.9.15
* io.vertx:vertx-jdbc-client:3.9.7 -> 3.9.15
* io.vertx:vertx-jdbc-client:3.9.7 -> 3.9.15
* io.vertx:vertx-jdbc-client:3.9.7 -> 3.9.15
* io.vertx:vertx-jdbc-client:3.9.7 -> 3.9.15
* junit:junit:4.12 -> 4.13.1
* mysql:mysql-connector-java:5.1.46 -> 8.0.31
* mysql:mysql-connector-java:5.1.49 -> 8.0.31
* org.apache.arrow:arrow-memory-netty:5.0.0 -> 6.0.0
* org.apache.arrow:arrow-vector:5.0.0 -> 6.0.0
* org.apache.avro:avro:1.10.0 -> 1.11.0
* org.apache.avro:avro:1.10.1 -> 1.11.0
* org.apache.avro:avro:1.7.4 -> 1.11.0
* org.apache.avro:avro:1.7.7 -> 1.11.0
* org.apache.avro:avro:1.7.7 -> 1.11.0
* org.apache.avro:avro:1.8.2 -> 1.11.0
* org.apache.avro:avro:1.8.2 -> 1.11.0
* org.apache.avro:avro:1.8.2 -> 1.11.0
* org.apache.calcite:calcite-core:1.26.0 -> 1.33.0
* org.apache.calcite:calcite-core:1.31.0 -> 1.33.0
* org.apache.commons:commons-compress:1.20 -> 1.21
* org.apache.commons:commons-compress:1.20 -> 1.21
* org.apache.commons:commons-compress:1.20 -> 1.21
* org.apache.flink:flink-avro-confluent-registry:1.16.1 -> 1.16.2
* org.apache.flink:flink-avro-confluent-registry:1.16.1 -> 1.16.2
* org.apache.flink:flink-clients:1.16.1 -> 1.16.2
* org.apache.flink:flink-clients:1.16.1 -> 1.16.2
* org.apache.flink:flink-clients:1.16.1 -> 1.16.2
* org.apache.flink:flink-clients:1.16.1 -> 1.16.2
* org.apache.flink:flink-connector-elasticsearch-base:1.16.1 -> 1.16.2
* org.apache.flink:flink-connector-elasticsearch-base:1.16.1 -> 1.16.2
* org.apache.flink:flink-connector-elasticsearch-base:1.16.1 -> 1.16.2
* org.apache.flink:flink-connector-elasticsearch6:1.16.1 -> 1.16.2
* org.apache.flink:flink-connector-elasticsearch7:1.16.1 -> 1.16.2
* org.apache.flink:flink-core:1.16.1 -> 1.16.2
* org.apache.flink:flink-core:1.16.1 -> 1.16.2
* org.apache.flink:flink-core:1.16.1 -> 1.16.2
* org.apache.flink:flink-core:1.16.1 -> 1.16.2
* org.apache.flink:flink-runtime:1.16.1 -> 1.16.2
* org.apache.flink:flink-runtime:1.16.1 -> 1.16.2
* org.apache.flink:flink-runtime:1.16.1 -> 1.16.2
* org.apache.flink:flink-runtime:1.16.1 -> 1.16.2
* org.apache.flink:flink-streaming-java:1.16.1 -> 1.16.2
* org.apache.flink:flink-streaming-java:1.16.1 -> 1.16.2
* org.apache.flink:flink-streaming-java:1.16.1 -> 1.16.2
* org.apache.flink:flink-streaming-java:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-api-java-bridge:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-api-java-bridge:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-api-java-bridge:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-api-java-bridge:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-common:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-common:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-common:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-common:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-planner-loader:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-planner-loader:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-runtime:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-runtime:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-runtime:1.16.1 -> 1.16.2
* org.apache.flink:flink-table-runtime:1.16.1 -> 1.16.2
* org.apache.flink:flink-yarn:1.16.1 -> 1.16.2
* org.apache.flink:flink-yarn:1.16.1 -> 1.16.2
* org.apache.flink:flink-yarn:1.16.1 -> 1.16.2
* org.apache.flink:flink-yarn:1.16.1 -> 1.16.2
* org.apache.hadoop:hadoop-client:2.7.5 -> 3.3.5
* org.apache.hadoop:hadoop-client:2.7.5 -> 3.3.5
* org.apache.hadoop:hadoop-common:2.6.0 -> 3.3.5
* org.apache.hadoop:hadoop-common:2.7.5 -> 3.3.5
* org.apache.hadoop:hadoop-common:2.7.5 -> 3.3.5
* org.apache.hadoop:hadoop-common:2.8.5 -> 3.3.5
* org.apache.hadoop:hadoop-common:3.1.0 -> 3.3.5
* org.apache.hadoop:hadoop-hdfs:2.6.0 -> 3.3.3
* org.apache.hadoop:hadoop-hdfs:2.7.5 -> 3.3.3
* org.apache.hadoop:hadoop-hdfs:2.7.5 -> 3.3.3
* org.apache.hadoop:hadoop-hdfs:2.8.5 -> 3.3.5
* org.apache.hadoop:hadoop-mapreduce-client-core:2.7.1 -> 2.10.2
* org.apache.hadoop:hadoop-mapreduce-client-core:2.7.5 -> 2.10.2
* org.apache.hadoop:hadoop-mapreduce-client-core:2.7.5 -> 2.10.2
* org.apache.hadoop:hadoop-mapreduce-client-core:2.8.5 -> 2.10.2
* org.apache.hadoop:hadoop-yarn-api:2.6.0 -> 3.3.1
* org.apache.hadoop:hadoop-yarn-api:2.7.5 -> 3.3.1
* org.apache.hadoop:hadoop-yarn-api:2.7.5 -> 3.3.1
* org.apache.hadoop:hadoop-yarn-api:2.8.5 -> 3.3.1
* org.apache.hadoop:hadoop-yarn-api:3.1.0 -> 3.3.1
* org.apache.hadoop:hadoop-yarn-api:3.1.0 -> 3.3.1
* org.apache.hadoop:hadoop-yarn-client:2.7.5 -> 2.10.2
* org.apache.hadoop:hadoop-yarn-client:2.7.5 -> 2.10.2
* org.apache.hadoop:hadoop-yarn-client:2.8.5 -> 2.10.2
* org.apache.hadoop:hadoop-yarn-common:2.6.0 -> 2.10.2
* org.apache.hadoop:hadoop-yarn-common:2.7.5 -> 2.10.2
* org.apache.hadoop:hadoop-yarn-common:2.7.5 -> 2.10.2
* org.apache.hadoop:hadoop-yarn-common:2.8.5 -> 2.10.2
* org.apache.hadoop:hadoop-yarn-common:3.1.0 -> 3.3.5
* org.apache.hadoop:hadoop-yarn-common:3.1.0 -> 3.3.5
* org.apache.hbase:hbase-client:1.4.3 -> 2.1.6
* org.apache.hbase:hbase-client:1.4.3 -> 2.1.6
* org.apache.hbase:hbase-client:2.2.0 -> 2.2.1
* org.apache.hive:hive-common:3.1.2 -> 4.0.0-alpha-2
* org.apache.hive:hive-exec:2.1.0 -> 4.0.0-alpha-2
* org.apache.hive:hive-exec:3.1.3 -> 4.0.0-alpha-2
* org.apache.hive:hive-jdbc:2.1.0 -> 4.0.0-alpha-2
* org.apache.hive:hive-metastore:3.1.2 -> 4.0.0-alpha-2
* org.apache.hive:hive-serde:2.1.0 -> 4.0.0-alpha-2
* org.apache.hive:hive-serde:3.1.2 -> 4.0.0-alpha-2
* org.apache.hive:hive-serde:3.1.3 -> 4.0.0-alpha-2
* org.apache.httpcomponents:httpclient:4.5.2 -> 4.5.13
* org.apache.httpcomponents:httpclient:4.5.2 -> 4.5.13
* org.apache.httpcomponents:httpclient:4.5.2 -> 4.5.13
* org.apache.httpcomponents:httpclient:4.5.3 -> 4.5.13
* org.apache.httpcomponents:httpclient:4.5.3 -> 4.5.13
* org.apache.httpcomponents:httpclient:4.5.3 -> 4.5.13
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-1.2-api:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-core:2.17.1 -> 2.20.0
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.logging.log4j:log4j-slf4j-impl:2.17.1 -> 2.17.2
* org.apache.parquet:parquet-avro:1.12.2 -> 1.13.0
* org.apache.parquet:parquet-hadoop:1.8.3 -> 1.11.0
* org.apache.poi:poi-ooxml:4.1.2 -> 5.1.0
* org.apache.poi:poi-ooxml:4.1.2 -> 5.1.0
* org.apache.solr:solr-solrj:8.8.2 -> 9.1.0
* org.codehaus.groovy:groovy-all:2.4.4 -> 2.5.18
* org.codehaus.groovy:groovy-all:2.4.4 -> 2.5.18
* org.datanucleus:datanucleus-core:5.0.1 -> 5.0.2
* org.datanucleus:datanucleus-rdbms:5.0.1 -> 6.0.0-m5
* org.elasticsearch.client:elasticsearch-rest-high-level-client:6.3.1 -> 8.0.0-alpha1
* org.elasticsearch.client:elasticsearch-rest-high-level-client:7.5.1 -> 8.0.0-alpha1
* org.influxdb:influxdb-java:2.21 -> 2.23
* org.postgresql:postgresql:42.2.19 -> 42.2.27
* org.slf4j:slf4j-log4j12:1.7.10 -> 1.7.34
* org.slf4j:slf4j-log4j12:1.7.5 -> 1.7.34

Auto-merge is enabled.